### PR TITLE
Use updated github API

### DIFF
--- a/issue/acme.go
+++ b/issue/acme.go
@@ -166,10 +166,10 @@ var numRE = regexp.MustCompile(`(?m)^#[0-9]+\t`)
 
 var milecache struct {
 	sync.Mutex
-	list []github.Milestone
+	list []*github.Milestone
 }
 
-func cachedMilestones() []github.Milestone {
+func cachedMilestones() []*github.Milestone {
 	milecache.Lock()
 	if milecache.list == nil {
 		milecache.list, _ = loadMilestones()

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -622,8 +622,8 @@ func listRepoIssues(opt github.IssueListByRepoOptions) ([]*github.Issue, error) 
 		}
 		issues, resp, err := client.Issues.ListByRepo(projectOwner, projectRepo, &xopt)
 		for i := range issues {
-			updateIssueCache(&issues[i])
-			all = append(all, &issues[i])
+			updateIssueCache(issues[i])
+			all = append(all, issues[i])
 		}
 		if err != nil {
 			return all, err
@@ -645,7 +645,7 @@ func listRepoIssues(opt github.IssueListByRepoOptions) ([]*github.Issue, error) 
 	return save, nil
 }
 
-func loadMilestones() ([]github.Milestone, error) {
+func loadMilestones() ([]*github.Milestone, error) {
 	// NOTE(rsc): There appears to be no paging possible.
 	all, _, err := client.Issues.ListMilestones(projectOwner, projectRepo, &github.MilestoneListOptions{
 		State: "open",
@@ -654,7 +654,7 @@ func loadMilestones() ([]github.Milestone, error) {
 		return nil, err
 	}
 	if all == nil {
-		all = []github.Milestone{}
+		all = []*github.Milestone{}
 	}
 	return all, nil
 }


### PR DESCRIPTION
The `github.com/google/go-github/github` library changed the types of a couple methods that `issue` uses, which prevents it from building cleanly with `go get`.  This solves the problem and everything seems to work, for me at least.