### PR TITLE
issue: fix wrap if containing multi-byte string

### DIFF
--- a/issue/issue.go
+++ b/issue/issue.go
@@ -246,6 +246,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -680,6 +681,9 @@ func wrap(t string, prefix string) string {
 				i = max - 1
 			}
 			i++
+			for !utf8.ValidString(s[:i]) {
+				i--
+			}
 			out += s[:i] + "\n" + prefix
 			s = s[i:]
 		}


### PR DESCRIPTION
e.g.)
The following text
```plain
あのイーハトーヴォのすきとおった風、(夏でも底に冷たさをもつ青いそら)、うつくしい森で飾られたモリーオ市、郊外のぎらぎらひかる草の波。
　またそのなかでいっしょになったたくさんのひとたち、(ファゼーロとロザーロ、羊飼のミーロや、顔の赤いこどもたち、地主のテーモ、山猫博士のボーガント・デストゥパーゴなど、いまこの暗い巨きな石の建物のなかで考えていると、みんなむかし風のなつかしい青い幻燈のように思われます。では、わたくしはいつかの小さなみだしをつけながら、しずかにあの年のイーハトーヴォの五月から十月までを書きつけましょう。(宮沢賢治)
```

results in
```plain
あのイーハトーヴォのすきとおった風、(夏でも底に冷たさをもつ青いそら)、うつくしい�
��で飾られたモリーオ市、郊外のぎらぎらひかる草の波。
　またそのなかでいっしょになったたくさんのひとたち、(ファゼーロとロザーロ、羊飼��
�ミーロや、顔の赤いこどもたち、地主のテーモ、山猫博士のボーガント・デストゥパー��
�など、いまこの暗い巨きな石の建物のなかで考えていると、みんなむかし風のなつかし��
�青い幻燈のように思われます。では、わたくしはいつかの小さなみだしをつけながら、��
�ずかにあの年のイーハトーヴォの五月から十月までを書きつけましょう。(宮沢賢治)
```
because newline(\n)s are inserted into a single rune with `wrap` function.

This PR fixes this.